### PR TITLE
Pinned version of sysdig

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,6 @@
 
 - name: sysdig | install package
   package:
-    name: '{{ sysdig_package }}'
+    name: '{{ sysdig_package }}-{{ sysdig_version }}'
     state: latest
 

--- a/vars/yum.yml
+++ b/vars/yum.yml
@@ -1,2 +1,4 @@
 ---
 sysdig_package: sysdig
+sysdig_version: 0.16.0-1.x86_64
+


### PR DESCRIPTION

A later version of sysdig has been deployed to artifactory which is causing basebuild to fail . This pins the version to known working.